### PR TITLE
계좌 개설 api 구현

### DIFF
--- a/src/main/java/com/example/fintech/account/controller/AccountController.java
+++ b/src/main/java/com/example/fintech/account/controller/AccountController.java
@@ -1,0 +1,28 @@
+package com.example.fintech.account.controller;
+
+import com.example.fintech.account.dto.CreateAccount;
+import com.example.fintech.account.service.AccountService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AccountController {
+    private final AccountService accountService;
+
+    /**
+     * 계좌 생성 API
+     */
+    @PostMapping("/account")
+    public CreateAccount.Response createAccount(
+            @RequestBody CreateAccount.Request request) {
+
+        var result = this.accountService.createAccount(request.getMemberId(),
+                request.getProductionId(), request.getBalance());
+
+        return CreateAccount.Response.from(result);
+    }
+
+}

--- a/src/main/java/com/example/fintech/account/domain/Account.java
+++ b/src/main/java/com/example/fintech/account/domain/Account.java
@@ -1,9 +1,11 @@
 package com.example.fintech.account.domain;
 
 import com.example.fintech.account.type.AccountStatus;
+import com.example.fintech.member.domain.Member;
 import com.example.fintech.production.domain.Production;
 import com.example.fintech.production.type.ProductionType;
 import lombok.*;
+import org.hibernate.annotations.GenericGenerator;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -20,8 +22,11 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public class Account {
     @Id
-    @GeneratedValue
+    @GenericGenerator(name = "USER_GENERATOR", strategy = "uuid")
     private String accountNumber;
+
+    @ManyToOne
+    private Member member;
 
     @ManyToOne
     private Production production;

--- a/src/main/java/com/example/fintech/account/domain/Account.java
+++ b/src/main/java/com/example/fintech/account/domain/Account.java
@@ -1,0 +1,45 @@
+package com.example.fintech.account.domain;
+
+import com.example.fintech.account.type.AccountStatus;
+import com.example.fintech.production.domain.Production;
+import com.example.fintech.production.type.ProductionType;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class Account {
+    @Id
+    @GeneratedValue
+    private String accountNumber;
+
+    @ManyToOne
+    private Production production;
+
+    @Enumerated(EnumType.STRING)
+    private ProductionType productionType;
+
+    @Enumerated(EnumType.STRING)
+    private AccountStatus accountStatus;
+
+    private Long balance;
+
+    private LocalDateTime registeredAt;
+    private LocalDateTime maturityAt;
+    private LocalDateTime unregisteredAt;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/fintech/account/dto/AccountDto.java
+++ b/src/main/java/com/example/fintech/account/dto/AccountDto.java
@@ -1,0 +1,43 @@
+package com.example.fintech.account.dto;
+
+import com.example.fintech.account.domain.Account;
+import com.example.fintech.production.type.ProductionType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AccountDto {
+    private String accountNumber;
+    private Long production;
+    private ProductionType productionType;
+    private Long userId; // 회원 식별 번호
+    private String memberId; // 회원 아이디
+    private String memberName;
+
+    private Long balance;
+
+    private LocalDateTime registeredAt;
+    private LocalDateTime maturityAt;
+    private LocalDateTime unregisteredAt;
+
+    // Entity -> Dto 변환
+    public static AccountDto fromEntity(Account account) {
+        return AccountDto.builder()
+                .accountNumber(account.getAccountNumber())
+                .production(account.getProduction().getId())
+                .productionType(account.getProductionType())
+                .userId(account.getMember().getId())
+                .memberId(account.getMember().getMemberId())
+                .memberName(account.getMember().getName())
+                .balance(account.getBalance())
+                .registeredAt(account.getRegisteredAt())
+                .maturityAt(account.getMaturityAt())
+                .unregisteredAt(account.getUnregisteredAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/fintech/account/dto/CreateAccount.java
+++ b/src/main/java/com/example/fintech/account/dto/CreateAccount.java
@@ -1,0 +1,44 @@
+package com.example.fintech.account.dto;
+
+import com.example.fintech.production.type.ProductionType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+public class CreateAccount {
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class Request {
+        private String memberId;
+        private Long productionId; // 가입할 계좌 상품 번호
+        private Long balance;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+        private String memberId;
+        private String memberName;
+        private String accountNumber;
+        private Long productionId;
+        private ProductionType productionType;
+        private LocalDateTime registeredAt;
+        private LocalDateTime maturityAt;
+
+        public static Response from(AccountDto accountDto){
+            return Response.builder()
+                    .memberId(accountDto.getMemberId())
+                    .memberName(accountDto.getMemberName())
+                    .accountNumber(accountDto.getAccountNumber())
+                    .productionId(accountDto.getProduction())
+                    .productionType(accountDto.getProductionType())
+                    .registeredAt(accountDto.getRegisteredAt())
+                    .maturityAt(accountDto.getMaturityAt())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/fintech/account/dto/CreateAccount.java
+++ b/src/main/java/com/example/fintech/account/dto/CreateAccount.java
@@ -9,6 +9,7 @@ public class CreateAccount {
     @Getter
     @Setter
     @AllArgsConstructor
+    @Builder
     public static class Request {
         private String memberId;
         private Long productionId; // 가입할 계좌 상품 번호

--- a/src/main/java/com/example/fintech/account/repository/AccountRepository.java
+++ b/src/main/java/com/example/fintech/account/repository/AccountRepository.java
@@ -1,0 +1,9 @@
+package com.example.fintech.account.repository;
+
+import com.example.fintech.account.domain.Account;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AccountRepository extends JpaRepository<Account, String> {
+}

--- a/src/main/java/com/example/fintech/account/repository/AccountRepository.java
+++ b/src/main/java/com/example/fintech/account/repository/AccountRepository.java
@@ -4,6 +4,13 @@ import com.example.fintech.account.domain.Account;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface AccountRepository extends JpaRepository<Account, String> {
+    boolean existsByAccountNumber(String accountNumber);
+
+    List<Account> findByProduction_id(Long productionId);
+
+    List<Account> findByMember_id(Long memberId);
 }

--- a/src/main/java/com/example/fintech/account/service/AccountService.java
+++ b/src/main/java/com/example/fintech/account/service/AccountService.java
@@ -79,23 +79,8 @@ public class AccountService {
         account.setRegisteredAt(LocalDateTime.now());
 
         this.accountRepository.save(account);
-        this.plusTotalUsers(productionId);
 
         return AccountDto.fromEntity(account);
-    }
-
-
-    /**
-     * 계좌 개설 시, 해당 계좌 상품 사용자 업데이트
-     */
-    public void plusTotalUsers(Long productionId) {
-        var production = this.productionRepository.findById(productionId).get();
-
-        Long totalUser = new Long(
-                this.accountRepository.findByProduction_id(productionId).size());
-
-        production.setTotalAccountsNum(totalUser);
-        this.productionRepository.save(production);
     }
 
     /**

--- a/src/main/java/com/example/fintech/account/service/AccountService.java
+++ b/src/main/java/com/example/fintech/account/service/AccountService.java
@@ -36,10 +36,6 @@ public class AccountService {
         Member member = this.memberRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new RuntimeException("사용자가 존재하지 않습니다."));
 
-        // test
-        boolean re = this.productionRepository.existsById(productionId);
-        System.out.println("exists 테스트 (productionId 존재하는가?)-> " + re);
-
         // 사용자 보유 계좌 조회 -> 5개 이상이면 계좌 개설할 수 없으므로 에러 발생
         int totalAccountNum =
                 this.accountRepository.findByMember_id(member.getId()).size();

--- a/src/main/java/com/example/fintech/account/service/AccountService.java
+++ b/src/main/java/com/example/fintech/account/service/AccountService.java
@@ -1,35 +1,124 @@
 package com.example.fintech.account.service;
 
+import com.example.fintech.account.domain.Account;
+import com.example.fintech.account.dto.AccountDto;
 import com.example.fintech.account.repository.AccountRepository;
+import com.example.fintech.account.type.AccountStatus;
+import com.example.fintech.member.domain.Member;
+import com.example.fintech.member.repository.MemberRepository;
+import com.example.fintech.production.domain.Production;
+import com.example.fintech.production.repository.ProductionRepository;
+import com.example.fintech.production.type.ProductionType;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Random;
 
 @Service
 @AllArgsConstructor
 public class AccountService {
-    Random random = new Random();
-
     private final AccountRepository accountRepository;
+    private final ProductionRepository productionRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 계좌 생성
+     */
+    @Transactional
+    public AccountDto createAccount(
+            String memberId, Long productionId, Long balance) {
+
+        Account account = new Account();
+
+        // 사용자가 존재하지 않는 경우 에러 발생
+        Member member = this.memberRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new RuntimeException("사용자가 존재하지 않습니다."));
+
+        // test
+        boolean re = this.productionRepository.existsById(productionId);
+        System.out.println("exists 테스트 (productionId 존재하는가?)-> " + re);
+
+        // 사용자 보유 계좌 조회 -> 5개 이상이면 계좌 개설할 수 없으므로 에러 발생
+        int totalAccountNum =
+                this.accountRepository.findByMember_id(member.getId()).size();
+        if (totalAccountNum >= 5) {
+            throw new RuntimeException("계좌를 개설할 수 없습니다." +
+                    " 최대 보유 가능 계좌 수는 5개 입니다. 현재 계좌 개수 -> " + totalAccountNum);
+        }
+
+        // 초기 금액이 작은 경우, 에러 발생
+        if (balance < 5000) {
+            throw new RuntimeException("초기 금액은 5000원부터 입니다.");
+        }
+
+        // 계좌 상품 종류가 존재하지 않는 상품인 경우 에러 발생
+        Production production = this.productionRepository.findById(productionId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 계좌 상품입니다."));
+
+        ProductionType type = production.getProductionCategory().getProductionType();
+
+        // 계좌 상품이 자유적금/정기적금에 해당하는 경우, 만기일자 설정
+        if (type != ProductionType.SAVINGS_ACCOUNT) {
+            int months = production.getContractPeriod();
+
+            LocalDateTime today = LocalDateTime.now();
+            LocalDateTime monthsAfterLocalDate = today.plusMonths(months);
+
+            account.setMaturityAt(monthsAfterLocalDate);
+        }
+
+        // Account entity 생성
+        account.setAccountNumber(createUniqueAccountNumber());
+        account.setProduction(production);
+        account.setProductionType(type);
+        account.setMember(member);
+        account.setAccountStatus(AccountStatus.IN_USE);
+        account.setBalance(balance);
+        account.setRegisteredAt(LocalDateTime.now());
+
+        this.accountRepository.save(account);
+        this.plusTotalUsers(productionId);
+
+        return AccountDto.fromEntity(account);
+    }
+
+
+    /**
+     * 계좌 개설 시, 해당 계좌 상품 사용자 업데이트
+     */
+    public void plusTotalUsers(Long productionId) {
+        var production = this.productionRepository.findById(productionId).get();
+
+        Long totalUser = new Long(
+                this.accountRepository.findByProduction_id(productionId).size());
+
+        production.setTotalAccountsNum(totalUser);
+        this.productionRepository.save(production);
+    }
+
+    /**
+     * 데이터베이스 계좌 번호 중복 검사
+     */
+    public String createUniqueAccountNumber() {
+        String accountNumber;
+        do {
+            accountNumber = createAccountNumber();
+        } while (this.accountRepository.existsByAccountNumber(accountNumber));
+        return accountNumber;
+    }
 
     /**
      * 계좌 번호 생성
      */
     public String createAccountNumber() {
+        Random random = new Random();
         int w = random.nextInt(900) + 100; // 3자리수 100~999
         int x = random.nextInt(9000) + 1000; // 4자리수 1000~9999
         int y = random.nextInt(9000) + 1000; // 4자리수 1000~9999
         int z = random.nextInt(90) + 10; // 2자리수 10~99
 
-        String accountNumber = String.format("%d-%d-%d-%d", w, x, y, z);
-
-        // DB 에 계좌번호가 존재한다면, 다시 메서드 호출해서 계좌번호 생성 반복
-        // 없는 경우에는 생성된 계좌번호로 결정
-        String newAccountNumber = this.accountRepository.findByAccountNumber(accountNumber)
-                .map(account -> this.createAccountNumber())
-                .orElse(accountNumber);
-
-        return newAccountNumber;
+        return String.format("%d-%d-%d-%d", w, x, y, z);
     }
 }

--- a/src/main/java/com/example/fintech/account/service/AccountService.java
+++ b/src/main/java/com/example/fintech/account/service/AccountService.java
@@ -1,0 +1,35 @@
+package com.example.fintech.account.service;
+
+import com.example.fintech.account.repository.AccountRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+@Service
+@AllArgsConstructor
+public class AccountService {
+    Random random = new Random();
+
+    private final AccountRepository accountRepository;
+
+    /**
+     * 계좌 번호 생성
+     */
+    public String createAccountNumber() {
+        int w = random.nextInt(900) + 100; // 3자리수 100~999
+        int x = random.nextInt(9000) + 1000; // 4자리수 1000~9999
+        int y = random.nextInt(9000) + 1000; // 4자리수 1000~9999
+        int z = random.nextInt(90) + 10; // 2자리수 10~99
+
+        String accountNumber = String.format("%d-%d-%d-%d", w, x, y, z);
+
+        // DB 에 계좌번호가 존재한다면, 다시 메서드 호출해서 계좌번호 생성 반복
+        // 없는 경우에는 생성된 계좌번호로 결정
+        String newAccountNumber = this.accountRepository.findByAccountNumber(accountNumber)
+                .map(account -> this.createAccountNumber())
+                .orElse(accountNumber);
+
+        return newAccountNumber;
+    }
+}

--- a/src/main/java/com/example/fintech/account/type/AccountStatus.java
+++ b/src/main/java/com/example/fintech/account/type/AccountStatus.java
@@ -1,0 +1,6 @@
+package com.example.fintech.account.type;
+
+public enum AccountStatus {
+    IN_USE,
+    UNREGISTERED
+}

--- a/src/main/java/com/example/fintech/member/domain/Member.java
+++ b/src/main/java/com/example/fintech/member/domain/Member.java
@@ -1,0 +1,35 @@
+package com.example.fintech.member.domain;
+
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class Member {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String memberId;
+    private String password;
+
+    private String simplePassword;
+
+    private String name;
+    private String email;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/fintech/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/fintech/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.example.fintech.member.repository;
+
+import com.example.fintech.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/example/fintech/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/fintech/member/repository/MemberRepository.java
@@ -4,6 +4,9 @@ import com.example.fintech.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByMemberId(String memberId);
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -6,3 +6,12 @@ values (2, 'FREE_SAVINGS');
 
 insert into production_category(id, production_type)
 values (3, 'INSTALMENT_SAVINGS');
+
+insert into member(id, member_id, password, simple_password, name, email, created_at, updated_at)
+values (1, 'hyeonju0121', 'guswn123456789', '123456', '유현주', 'a01085249773@gmail.com', now(), now());
+
+insert into member(id, member_id, password, simple_password, name, email, created_at, updated_at)
+values (2, 'chichilove0621', 'ilovepet123', '180621', '치치', 'chichi0621@gmail.com', now(), now());
+
+insert into member(id, member_id, password, simple_password, name, email, created_at, updated_at)
+values (3, 'zizh121', 'zhun9317@!', '567890','김지훈', 'zizh121@naver.com', now(), now());

--- a/src/test/http/account.http
+++ b/src/test/http/account.http
@@ -1,0 +1,29 @@
+### createAccount
+POST http://localhost:8080/account
+Content-Type: application/json
+
+{
+  "memberId": "hyeonju0121",
+  "productionId": 1,
+  "balance": 5000
+}
+
+### createAccount
+POST http://localhost:8080/account
+Content-Type: application/json
+
+{
+  "memberId": "hyeonju0121",
+  "productionId": 2,
+  "balance": 12000
+}
+
+### createAccount
+POST http://localhost:8080/account
+Content-Type: application/json
+
+{
+  "memberId": "hyeonju0121",
+  "productionId": 3,
+  "balance": 8000
+}

--- a/src/test/java/com/example/fintech/controller/AccountControllerTest.java
+++ b/src/test/java/com/example/fintech/controller/AccountControllerTest.java
@@ -1,0 +1,79 @@
+package com.example.fintech.controller;
+
+import com.example.fintech.account.controller.AccountController;
+import com.example.fintech.account.dto.AccountDto;
+import com.example.fintech.account.dto.CreateAccount;
+import com.example.fintech.account.service.AccountService;
+import com.example.fintech.production.type.ProductionType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AccountController.class)
+public class AccountControllerTest {
+    @MockBean
+    private AccountService accountService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("계좌 개설")
+    void successCreateAccount() throws Exception {
+        //given
+        given(accountService.createAccount(anyString(), anyLong(), anyLong()))
+                .willReturn(getAccountDto());
+
+        CreateAccount.Request request = CreateAccount.Request.builder()
+                .memberId("hyeonju0121")
+                .productionId(1L)
+                .balance(5000L)
+                .build();
+
+        mockMvc.perform(post("/account")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.accountNumber").value("714-3722-6286-62"))
+                .andExpect(jsonPath("$.memberId").value("hyeonju0121"))
+                .andExpect(jsonPath("$.memberName").value("유현주"))
+                .andExpect(jsonPath("$.productionId").value(1))
+                .andExpect(jsonPath("$.productionType").value("SAVINGS_ACCOUNT"))
+                .andExpect(jsonPath("$.maturityAt").isNotEmpty())
+                .andExpect(jsonPath("$.registeredAt").isNotEmpty())
+                .andDo(print());
+    }
+
+    private AccountDto getAccountDto() {
+        return AccountDto.builder()
+                .accountNumber("714-3722-6286-62")
+                .production(1L)
+                .productionType(ProductionType.SAVINGS_ACCOUNT)
+                .userId(1L)
+                .memberId("hyeonju0121")
+                .memberName("유현주")
+                .balance(5000L)
+                .registeredAt(LocalDateTime.now())
+                .maturityAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/test/java/com/example/fintech/service/AccountServiceTest.java
+++ b/src/test/java/com/example/fintech/service/AccountServiceTest.java
@@ -1,0 +1,98 @@
+package com.example.fintech.service;
+
+import com.example.fintech.account.domain.Account;
+import com.example.fintech.account.dto.AccountDto;
+import com.example.fintech.account.repository.AccountRepository;
+import com.example.fintech.account.service.AccountService;
+import com.example.fintech.member.domain.Member;
+import com.example.fintech.member.repository.MemberRepository;
+import com.example.fintech.production.domain.Production;
+import com.example.fintech.production.domain.ProductionCategory;
+import com.example.fintech.production.repository.ProductionRepository;
+import com.example.fintech.production.type.ProductionType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class AccountServiceTest {
+    @Mock
+    private AccountRepository accountRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private ProductionRepository productionRepository;
+
+    @InjectMocks
+    private AccountService accountService;
+
+    @Test
+    @DisplayName("계좌 개설 서비스 테스트")
+    void createAccountSuccess() {
+        //given
+        String memberId = "testMemberId";
+        Long productionId = 1L;
+        Long balance = 5000L;
+
+        Member member = new Member();
+        member.setId(1L);
+
+        Production production = new Production();
+        production.setId(1L);
+
+        ProductionCategory productionCategory = new ProductionCategory();
+        productionCategory.setProductionType(ProductionType.FREE_SAVINGS);
+        production.setProductionCategory(productionCategory);
+
+        given(memberRepository.findByMemberId(anyString())).willReturn(Optional.of(member));
+        given(productionRepository.findById(anyLong())).willReturn(Optional.of(production));
+        given(accountRepository.findByMember_id(anyLong())).willReturn(List.of(new Account(), new Account(), new Account(), new Account()));
+
+        // when
+        AccountDto result = accountService.createAccount(memberId, productionId, balance);
+
+        // then
+        verify(accountRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("사용자 보유 계좌 5개 이상일 경우 예외 발생 테스트")
+    void createAccountWithThrowsException() {
+        //given
+        String memberId = "testMemberId";
+        Long productionId = 1L;
+        Long balance = 5000L;
+
+        Member member = new Member();
+        member.setId(1L);
+
+        List<Account> accounts = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            Account account = new Account();
+            accounts.add(account);
+        }
+
+        when(memberRepository.findByMemberId(anyString())).thenReturn(Optional.of(member));
+        when(accountRepository.findByMember_id(anyLong())).thenReturn(accounts);
+
+        //when, then
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> accountService.createAccount(memberId, productionId, balance))
+                .withMessageContaining("계좌를 개설할 수 없습니다. 최대 보유 가능 계좌 수는 5개 입니다.");
+    }
+}


### PR DESCRIPTION
## 작업 내용 (Contents)
<!-- 이 PR에서 어떤 점들이 변경되었는지 기술해주세요.-->
- 계좌 개설 api 구현
- 계좌를 개설할 때, 사용자 아이디 입력을 받아야 하므로 임시 Member Entity&Repository 생성 후 초기 데이터를 설정해 줬다.

<br>

## 기타 사항 (Etc)
<!-- PR 에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등 -->
**[계좌번호 생성]**
- 현재 계좌번호를 생성하는 메서드에 중복 검사가 빈번하게 발생한다면, 데이터베이스의 계좌번호의 중복 여부를 확인하는 작업은 성능에 영향을 미칠 수 있을 것이라고 생각이 들었다.
- 추후 캐싱을 사용하여 미리 생성된 계좌번호를 일시적으로 보관하여 중복 검사를 최소화하는 방안도 고려해야 할 것 같다.

**[계좌번호 개설 시, 해당 계좌 사용자 현황 업데이트]**
- 초기에 사용자가 계좌를 개설할 때마다 이 메서드를 호출하여 업데이트하는 방식으로 구현을 진행했었다.
- 하지만, 관리자 입장에서 해당 상품의 사용자 수를 판단하는 목적으로 업데이트 기능을 생각한 것이기 때문에, 계좌번호를 개설할 때마다 사용자 수 업데이트는 실시간으로 필요한 것이 아니라고 판단이 들었다.
- 따라서 사용자가 계좌를 개설할 때마다 업데이트하는 방식이 아닌 스케줄링으로 주기적으로 업데이트하는 방식으로 변경했다. 
- **추후, 스케줄링으로 주기적으로 사용자 수 업데이트 구현 필요**

**[pk 를 String 타입으로 지정 시 발생하는 오류]**
- account 테이블의 pk 가 String 타입으로 지정되어 있어서 오류가 발생하였다.
UUID를 사용하여 String 타입의 계좌번호를 pk로 사용할 수 있도록 변경해 주었다.
- [https://stackoverflow.com/questions/18622716/how-to-use-id-with-string-type-in-jpa-hibernate](url)
<br>

## 테스트 (Test)
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요. -->
- [x] 계좌 개설 서비스 테스트
- [x] 사용자 보유 계좌 5개 이상일 경우 예외 발생 테스트
- [x] API 테스트
