### PR TITLE
계좌 개설 api 코드 수정 

### DIFF
--- a/src/main/java/com/example/fintech/account/controller/AccountController.java
+++ b/src/main/java/com/example/fintech/account/controller/AccountController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.validation.Valid;
+
 @RestController
 @RequiredArgsConstructor
 public class AccountController {
@@ -17,7 +19,7 @@ public class AccountController {
      */
     @PostMapping("/account")
     public CreateAccount.Response createAccount(
-            @RequestBody CreateAccount.Request request) {
+            @RequestBody @Valid CreateAccount.Request request) {
 
         var result = this.accountService.createAccount(request.getMemberId(),
                 request.getProductionId(), request.getBalance());

--- a/src/main/java/com/example/fintech/account/dto/CreateAccount.java
+++ b/src/main/java/com/example/fintech/account/dto/CreateAccount.java
@@ -3,6 +3,8 @@ package com.example.fintech.account.dto;
 import com.example.fintech.production.type.ProductionType;
 import lombok.*;
 
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
 public class CreateAccount {
@@ -11,8 +13,12 @@ public class CreateAccount {
     @AllArgsConstructor
     @Builder
     public static class Request {
+        @NotNull
         private String memberId;
+        @NotNull
         private Long productionId; // 가입할 계좌 상품 번호
+        @NotNull
+        @Min(5000)
         private Long balance;
     }
 

--- a/src/main/java/com/example/fintech/account/repository/AccountRepository.java
+++ b/src/main/java/com/example/fintech/account/repository/AccountRepository.java
@@ -1,16 +1,15 @@
 package com.example.fintech.account.repository;
 
 import com.example.fintech.account.domain.Account;
+import com.example.fintech.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 
 @Repository
 public interface AccountRepository extends JpaRepository<Account, String> {
     boolean existsByAccountNumber(String accountNumber);
 
-    List<Account> findByProduction_id(Long productionId);
+    Integer countByMember(Member member);
 
-    List<Account> findByMember_id(Long memberId);
 }

--- a/src/main/java/com/example/fintech/account/service/AccountService.java
+++ b/src/main/java/com/example/fintech/account/service/AccountService.java
@@ -86,7 +86,7 @@ public class AccountService {
     /**
      * 데이터베이스 계좌 번호 중복 검사
      */
-    private String createUniqueAccountNumber() {
+    public String createUniqueAccountNumber() {
         String accountNumber;
         do {
             accountNumber = createAccountNumber();
@@ -97,7 +97,7 @@ public class AccountService {
     /**
      * 계좌 번호 생성
      */
-    private String createAccountNumber() {
+    public String createAccountNumber() {
         Random random = new Random();
         int w = random.nextInt(900) + 100; // 3자리수 100~999
         int x = random.nextInt(9000) + 1000; // 4자리수 1000~9999

--- a/src/main/java/com/example/fintech/account/service/AccountService.java
+++ b/src/main/java/com/example/fintech/account/service/AccountService.java
@@ -8,6 +8,7 @@ import com.example.fintech.member.domain.Member;
 import com.example.fintech.member.repository.MemberRepository;
 import com.example.fintech.production.domain.Production;
 import com.example.fintech.production.repository.ProductionRepository;
+import com.example.fintech.production.type.ProductionStatus;
 import com.example.fintech.production.type.ProductionType;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,22 +37,11 @@ public class AccountService {
         Member member = this.memberRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new RuntimeException("사용자가 존재하지 않습니다."));
 
-        // 사용자 보유 계좌 조회 -> 5개 이상이면 계좌 개설할 수 없으므로 에러 발생
-        int totalAccountNum =
-                this.accountRepository.findByMember_id(member.getId()).size();
-        if (totalAccountNum >= 5) {
-            throw new RuntimeException("계좌를 개설할 수 없습니다." +
-                    " 최대 보유 가능 계좌 수는 5개 입니다. 현재 계좌 개수 -> " + totalAccountNum);
-        }
-
-        // 초기 금액이 작은 경우, 에러 발생
-        if (balance < 5000) {
-            throw new RuntimeException("초기 금액은 5000원부터 입니다.");
-        }
-
         // 계좌 상품 종류가 존재하지 않는 상품인 경우 에러 발생
         Production production = this.productionRepository.findById(productionId)
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 계좌 상품입니다."));
+
+        this.validateCreateAccount(member, production);
 
         ProductionType type = production.getProductionCategory().getProductionType();
 
@@ -80,9 +70,23 @@ public class AccountService {
     }
 
     /**
+     * 계좌 생성 검증 부분
+     */
+    private void validateCreateAccount(Member member, Production production) {
+        // 사용자 보유 계좌 확인
+        if(this.accountRepository.countByMember(member) >= 5) {
+            throw new RuntimeException("사용자 최대 보유 가능 계좌는 5개 입니다.");
+        }
+        // 계좌 상품 판매 상태 확인
+        if(production.getProductionStatus() == ProductionStatus.SUSPENSION_OF_SALES) {
+            throw new RuntimeException("판매 중지된 계좌 상품입니다.");
+        }
+    }
+
+    /**
      * 데이터베이스 계좌 번호 중복 검사
      */
-    public String createUniqueAccountNumber() {
+    private String createUniqueAccountNumber() {
         String accountNumber;
         do {
             accountNumber = createAccountNumber();
@@ -93,7 +97,7 @@ public class AccountService {
     /**
      * 계좌 번호 생성
      */
-    public String createAccountNumber() {
+    private String createAccountNumber() {
         Random random = new Random();
         int w = random.nextInt(900) + 100; // 3자리수 100~999
         int x = random.nextInt(9000) + 1000; // 4자리수 1000~9999

--- a/src/test/java/com/example/fintech/controller/AccountControllerTest.java
+++ b/src/test/java/com/example/fintech/controller/AccountControllerTest.java
@@ -42,17 +42,13 @@ public class AccountControllerTest {
         given(accountService.createAccount(anyString(), anyLong(), anyLong()))
                 .willReturn(getAccountDto());
 
-        CreateAccount.Request request = CreateAccount.Request.builder()
-                .memberId("hyeonju0121")
-                .productionId(1L)
-                .balance(5000L)
-                .build();
-
+        //when, then
         mockMvc.perform(post("/account")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+                        .content(objectMapper.writeValueAsString(
+                                new CreateAccount.Request("hyeonju0121", 1L, 5000L)
+                        )))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.accountNumber").value("714-3722-6286-62"))
                 .andExpect(jsonPath("$.memberId").value("hyeonju0121"))
                 .andExpect(jsonPath("$.memberName").value("유현주"))


### PR DESCRIPTION
## 작업 내용 (Contents)
<!-- 이 PR에서 어떤 점들이 변경되었는지 기술해주세요.-->
- 계좌 개설 api 코드 수정
- createAccount 내에 있는 사용자 보유 계좌 수와 계좌 상품 상태를 따로 유효성 검증을 위한 validateCreateAccount 메서드를 생성해 분리함 
- 계좌 개설 api 테스트 코드 수정 및 추가

<br>

## 기타 사항 (Etc)
<!-- PR 에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등 -->
- 

<br>

## 테스트 (Test)
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요. -->
- [x] 계좌 개설 서비스 테스트
- [x] 사용자가 존재하지 않는 경우 - 계좌 생성 실패 
- [x] 사용자 보유 계좌 5개 이상인 경우 - 계좌 생성 실패
- [x] 해당 계좌 상품 종류가 존재하지 않는 경우 - 계좌 생성 실패
- [x] 해당 계좌 상품이 판매 중지된 경우 - 계좌 생성 실패
- [x] API 테스트
