### PR TITLE
계좌 해지 api 구현

### DIFF
--- a/src/main/java/com/example/fintech/account/controller/AccountController.java
+++ b/src/main/java/com/example/fintech/account/controller/AccountController.java
@@ -1,8 +1,10 @@
 package com.example.fintech.account.controller;
 
 import com.example.fintech.account.dto.CreateAccount;
+import com.example.fintech.account.dto.DeleteAccount;
 import com.example.fintech.account.service.AccountService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,4 +29,17 @@ public class AccountController {
         return CreateAccount.Response.from(result);
     }
 
+    /**
+     * 계좌 해지 API
+     */
+    @DeleteMapping("/account")
+    public DeleteAccount.Response deleteAccount(
+            @RequestBody @Valid DeleteAccount.Request request) {
+
+        var result = this.accountService.deleteAccount(
+                request.getMemberId(), request.getAccountNumber(),
+                request.getSimplePassword(), request.getTransferAccountNumber());
+
+        return DeleteAccount.Response.from(result);
+    }
 }

--- a/src/main/java/com/example/fintech/account/dto/AccountDto.java
+++ b/src/main/java/com/example/fintech/account/dto/AccountDto.java
@@ -1,6 +1,7 @@
 package com.example.fintech.account.dto;
 
 import com.example.fintech.account.domain.Account;
+import com.example.fintech.account.type.AccountStatus;
 import com.example.fintech.production.type.ProductionType;
 import lombok.*;
 
@@ -20,6 +21,7 @@ public class AccountDto {
     private String memberName;
 
     private Long balance;
+    private AccountStatus accountStatus;
 
     private LocalDateTime registeredAt;
     private LocalDateTime maturityAt;
@@ -35,6 +37,7 @@ public class AccountDto {
                 .memberId(account.getMember().getMemberId())
                 .memberName(account.getMember().getName())
                 .balance(account.getBalance())
+                .accountStatus(account.getAccountStatus())
                 .registeredAt(account.getRegisteredAt())
                 .maturityAt(account.getMaturityAt())
                 .unregisteredAt(account.getUnregisteredAt())

--- a/src/main/java/com/example/fintech/account/dto/DeleteAccount.java
+++ b/src/main/java/com/example/fintech/account/dto/DeleteAccount.java
@@ -1,13 +1,15 @@
 package com.example.fintech.account.dto;
 
+import com.example.fintech.account.type.AccountStatus;
 import com.example.fintech.production.type.ProductionType;
 import lombok.*;
 
-import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import java.time.LocalDateTime;
 
-public class CreateAccount {
+public class DeleteAccount {
     @Getter
     @Setter
     @AllArgsConstructor
@@ -15,11 +17,13 @@ public class CreateAccount {
     public static class Request {
         @NotNull
         private String memberId;
-        @NotNull
-        private Long productionId; // 가입할 계좌 상품 번호
-        @NotNull
-        @Min(0)
-        private Long balance;
+        @NotBlank
+        private String accountNumber;
+        @NotBlank
+        @Size(min = 6, max = 6, message = "6자리 간편비밀번호를 입력해주세요.")
+        private String simplePassword;
+
+        private String transferAccountNumber; // 적금 상품 해지시, 이체받을 계좌번호
     }
 
     @Getter
@@ -31,21 +35,20 @@ public class CreateAccount {
         private String memberId;
         private String memberName;
         private String accountNumber;
-        private Long productionId;
         private ProductionType productionType;
-        private LocalDateTime registeredAt;
-        private LocalDateTime maturityAt;
+        private AccountStatus accountStatus;
+        private LocalDateTime unRegisteredAt;
 
-        public static Response from(AccountDto accountDto){
+        public static DeleteAccount.Response from(AccountDto accountDto){
             return Response.builder()
                     .memberId(accountDto.getMemberId())
                     .memberName(accountDto.getMemberName())
                     .accountNumber(accountDto.getAccountNumber())
-                    .productionId(accountDto.getProduction())
                     .productionType(accountDto.getProductionType())
-                    .registeredAt(accountDto.getRegisteredAt())
-                    .maturityAt(accountDto.getMaturityAt())
+                    .accountStatus(accountDto.getAccountStatus())
+                    .unRegisteredAt(accountDto.getUnregisteredAt())
                     .build();
         }
     }
+
 }

--- a/src/main/java/com/example/fintech/account/repository/AccountRepository.java
+++ b/src/main/java/com/example/fintech/account/repository/AccountRepository.java
@@ -5,10 +5,14 @@ import com.example.fintech.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 
 @Repository
 public interface AccountRepository extends JpaRepository<Account, String> {
     boolean existsByAccountNumber(String accountNumber);
+
+    Optional<Account> findByAccountNumber(String accountNumber);
 
     Integer countByMember(Member member);
 

--- a/src/main/java/com/example/fintech/account/service/AccountService.java
+++ b/src/main/java/com/example/fintech/account/service/AccountService.java
@@ -122,9 +122,6 @@ public class AccountService {
         Long transferAccountBalance = transferAccount.getBalance() + account.getBalance();
         transferAccount.setBalance(transferAccountBalance);
         account.setBalance(0L);
-
-        this.accountRepository.save(transferAccount);
-        this.accountRepository.save(account);
     }
 
     /**

--- a/src/test/http/account.http
+++ b/src/test/http/account.http
@@ -5,7 +5,7 @@ Content-Type: application/json
 {
   "memberId": "hyeonju0121",
   "productionId": 1,
-  "balance": 5000
+  "balance": 0
 }
 
 ### createAccount
@@ -26,4 +26,15 @@ Content-Type: application/json
   "memberId": "hyeonju0121",
   "productionId": 3,
   "balance": 8000
+}
+
+### deleteAccount
+DELETE http://localhost:8080/account
+Content-Type: application/json
+
+{
+  "memberId": "hyeonju0121",
+  "accountNumber": "981-1925-9394-59",
+  "simplePassword": "123456",
+  "transferAccountNumber": "989-5520-4912-11"
 }

--- a/src/test/java/com/example/fintech/controller/AccountControllerTest.java
+++ b/src/test/java/com/example/fintech/controller/AccountControllerTest.java
@@ -3,7 +3,9 @@ package com.example.fintech.controller;
 import com.example.fintech.account.controller.AccountController;
 import com.example.fintech.account.dto.AccountDto;
 import com.example.fintech.account.dto.CreateAccount;
+import com.example.fintech.account.dto.DeleteAccount;
 import com.example.fintech.account.service.AccountService;
+import com.example.fintech.account.type.AccountStatus;
 import com.example.fintech.production.type.ProductionType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
@@ -20,6 +22,7 @@ import java.time.LocalDateTime;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -59,6 +62,30 @@ public class AccountControllerTest {
                 .andDo(print());
     }
 
+    @Test
+    @DisplayName("계좌 해지")
+    void successDeleteAccount() throws Exception {
+        //given
+        given(accountService.deleteAccount(anyString(), anyString(), anyString(), anyString()))
+                .willReturn(getAccountDto());
+
+        //when
+        //then
+        mockMvc.perform(delete("/account")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new DeleteAccount.Request("hyeonju0121", "714-3722-6286-62", "123456", "")
+                        )))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accountNumber").value("714-3722-6286-62"))
+                .andExpect(jsonPath("$.memberId").value("hyeonju0121"))
+                .andExpect(jsonPath("$.memberName").value("유현주"))
+                .andExpect(jsonPath("$.productionType").value("SAVINGS_ACCOUNT"))
+                .andExpect(jsonPath("$.accountStatus").value("UNREGISTERED"))
+                .andDo(print());
+    }
+
+
     private AccountDto getAccountDto() {
         return AccountDto.builder()
                 .accountNumber("714-3722-6286-62")
@@ -68,6 +95,7 @@ public class AccountControllerTest {
                 .memberId("hyeonju0121")
                 .memberName("유현주")
                 .balance(5000L)
+                .accountStatus(AccountStatus.UNREGISTERED)
                 .registeredAt(LocalDateTime.now())
                 .maturityAt(LocalDateTime.now())
                 .build();

--- a/src/test/java/com/example/fintech/service/AccountServiceTest.java
+++ b/src/test/java/com/example/fintech/service/AccountServiceTest.java
@@ -4,6 +4,7 @@ import com.example.fintech.account.domain.Account;
 import com.example.fintech.account.dto.AccountDto;
 import com.example.fintech.account.repository.AccountRepository;
 import com.example.fintech.account.service.AccountService;
+import com.example.fintech.account.type.AccountStatus;
 import com.example.fintech.member.domain.Member;
 import com.example.fintech.member.repository.MemberRepository;
 import com.example.fintech.production.domain.Production;
@@ -75,6 +76,114 @@ public class AccountServiceTest {
         verify(accountRepository, times(1)).save(captor.capture());
         assertEquals("testMemberId", accountDto.getMemberId());
         assertEquals(1L, accountDto.getProduction());
+    }
+
+    @Test
+    @DisplayName("계좌 해지 서비스 테스트 - 입출금 계좌")
+    void deleteAccountSavingsAccountSuccess() {
+        //given
+        Member member = Member.builder()
+                .id(1L)
+                .memberId("testMemberId")
+                .name("testUserName")
+                .simplePassword("123456")
+                .build();
+
+        given(memberRepository.findByMemberId(anyString()))
+                .willReturn(Optional.of(member));
+
+        ProductionCategory productionCategory = ProductionCategory.builder()
+                .id(1L)
+                .productionType(ProductionType.SAVINGS_ACCOUNT)
+                .build();
+
+        Production production = Production.builder()
+                .id(1L)
+                .productionCategory(productionCategory)
+                .build();
+
+        Account account = Account.builder()
+                .accountNumber("714-3722-6286-62")
+                .production(production)
+                .productionType(ProductionType.SAVINGS_ACCOUNT)
+                .member(member)
+                .balance(0L)
+                .build();
+        given(accountRepository.findByAccountNumber(anyString()))
+                .willReturn(Optional.of(account));
+
+        ArgumentCaptor<Account> captor = ArgumentCaptor.forClass(Account.class);
+
+        // when
+        AccountDto accountDto = accountService.deleteAccount(
+                "testMemberId", "714-3722-6286-62",
+                "123456", "");
+
+        // then
+        verify(accountRepository, times(1)).save(captor.capture());
+        assertEquals("testMemberId", accountDto.getMemberId());
+        assertEquals(1L, accountDto.getUserId());
+        assertEquals("714-3722-6286-62", captor.getValue().getAccountNumber());
+        assertEquals(AccountStatus.UNREGISTERED, captor.getValue().getAccountStatus());
+    }
+
+    @Test
+    @DisplayName("계좌 해지 서비스 테스트 - 적금 계좌")
+    void deleteAccountSuccess() {
+        //given
+        Member member = Member.builder()
+                .id(1L)
+                .memberId("testMemberId")
+                .name("testUserName")
+                .simplePassword("123456")
+                .build();
+
+        given(memberRepository.findByMemberId(anyString()))
+                .willReturn(Optional.of(member));
+
+        ProductionCategory productionCategory = ProductionCategory.builder()
+                .id(2L)
+                .productionType(ProductionType.INSTALMENT_SAVINGS)
+                .build();
+
+        Production production = Production.builder()
+                .id(1L)
+                .productionCategory(productionCategory)
+                .build();
+
+        Account account = Account.builder()
+                .accountNumber("714-3722-6286-62")
+                .production(production)
+                .productionType(ProductionType.INSTALMENT_SAVINGS)
+                .member(member)
+                .balance(20000L)
+                .build();
+
+        Account transferAccount = Account.builder()
+                .accountNumber("981-1925-9394-59")
+                .production(production)
+                .productionType(ProductionType.INSTALMENT_SAVINGS)
+                .member(member)
+                .balance(0L)
+                .build();
+
+        given(accountRepository.findByAccountNumber(anyString()))
+                .willReturn(Optional.of(account));
+
+        // when
+        AccountDto accountDto = accountService.deleteAccount(
+                "testMemberId", "714-3722-6286-62",
+                "123456", "981-1925-9394-59");
+
+        // then
+        ArgumentCaptor<Account> captor = ArgumentCaptor.forClass(Account.class);
+        verify(accountRepository, times(1)).save(captor.capture());
+
+        assertEquals("testMemberId", accountDto.getMemberId());
+        assertEquals(1L, accountDto.getUserId());
+        assertEquals(0L, transferAccount.getBalance());
+        assertEquals("714-3722-6286-62", captor.getValue().getAccountNumber());
+        assertEquals(AccountStatus.UNREGISTERED, captor.getValue().getAccountStatus());
     }
 
     @Test
@@ -153,4 +262,155 @@ public class AccountServiceTest {
                 .isThrownBy(() -> accountService.createAccount("testMemberId", 1L, 5000L))
                 .withMessageContaining("판매 중지된 계좌 상품입니다.");
     }
+
+    @Test
+    @DisplayName("사용자가 존재하지 않는 경우 - 계좌 해지 실패")
+    void deleteAccountFailed_UserNotFound() {
+        //given
+        given(memberRepository.findByMemberId(anyString()))
+                .willReturn(Optional.empty());
+
+        //when
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> accountService.deleteAccount(
+                        "testMemberId", "714-3722-6286-62",
+                        "123456", ""))
+                .withMessageContaining("사용자가 존재하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("간편 비밀번호가 일치하지 않는 경우 - 계좌 해지 실패")
+    void deleteAccountFailed_SimplePasswordUnMatch() {
+        //given
+        Member member = Member.builder()
+                .id(1L)
+                .memberId("testMemberId")
+                .simplePassword("123456").build();
+        given(memberRepository.findByMemberId(anyString()))
+                .willReturn(Optional.of(member));
+
+        //when
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> accountService.deleteAccount(
+                        "testMemberId", "accountNumber",
+                        "wrongPassword", null))
+                .withMessageContaining("간편 비밀번호가 일치하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("계좌번호가 존재하지 않는 경우 - 계좌 해지 실패")
+    void deleteAccountFailed_AccountNotFound() {
+        //given
+        Member member = Member.builder()
+                .id(1L)
+                .memberId("testMemberId")
+                .simplePassword("123456").build();
+        given(memberRepository.findByMemberId(anyString()))
+                .willReturn(Optional.of(member));
+
+        given(accountRepository.findByAccountNumber(anyString()))
+                .willReturn(Optional.empty());
+
+        //when
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> accountService.deleteAccount(
+                        "testMemberId", "714-3722-6286-62",
+                        "123456", ""))
+                .withMessageContaining("계좌번호가 존재하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("계좌번호 소유주가 다른 경우 - 계좌 해지 실패")
+    void deleteAccountFailed_userUnMatch() {
+        //given
+        Member member = Member.builder()
+                .id(1L)
+                .memberId("testMemberId")
+                .name("testUserName")
+                .simplePassword("123456")
+                .build();
+
+        Member otherMember = Member.builder()
+                .id(2L)
+                .memberId("testMemberId2")
+                .name("testUserName2")
+                .simplePassword("001122")
+                .build();
+
+        given(memberRepository.findByMemberId(anyString()))
+                .willReturn(Optional.of(member));
+
+        ProductionCategory productionCategory = ProductionCategory.builder()
+                .id(1L)
+                .productionType(ProductionType.SAVINGS_ACCOUNT)
+                .build();
+
+        Production production = Production.builder()
+                .id(1L)
+                .productionCategory(productionCategory)
+                .build();
+
+        Account otherAccount = Account.builder()
+                .accountNumber("714-3722-6286-62")
+                .production(production)
+                .productionType(ProductionType.SAVINGS_ACCOUNT)
+                .member(otherMember)
+                .balance(0L)
+                .build();
+
+        given(accountRepository.findByAccountNumber(anyString()))
+                .willReturn(Optional.of(otherAccount));
+
+        //when
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> accountService.deleteAccount(
+                        "testMemberId", "714-3722-6286-62",
+                        "123456", ""))
+                .withMessageContaining("사용자와 계좌 소유주가 일치하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("계좌가 이미 해지 상태인 경우 - 계좌 해지 실패")
+    void deleteAccountFailed_alreadyUnregistered() {
+        //given
+        Member member = Member.builder()
+                .id(1L)
+                .memberId("testMemberId")
+                .name("testUserName")
+                .simplePassword("123456")
+                .build();
+
+        given(memberRepository.findByMemberId(anyString()))
+                .willReturn(Optional.of(member));
+
+        ProductionCategory productionCategory = ProductionCategory.builder()
+                .id(1L)
+                .productionType(ProductionType.SAVINGS_ACCOUNT)
+                .build();
+
+        Production production = Production.builder()
+                .id(1L)
+                .productionCategory(productionCategory)
+                .build();
+
+        Account account = Account.builder()
+                .accountNumber("714-3722-6286-62")
+                .production(production)
+                .productionType(ProductionType.SAVINGS_ACCOUNT)
+                .member(member)
+                .balance(0L)
+                .accountStatus(AccountStatus.UNREGISTERED)
+                .build();
+
+        given(accountRepository.findByAccountNumber(anyString()))
+                .willReturn(Optional.of(account));
+
+        //when
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> accountService.deleteAccount(
+                        "testMemberId", "714-3722-6286-62",
+                        "123456", ""))
+                .withMessageContaining("이미 해지된 계좌입니다.");
+    }
+
 }


### PR DESCRIPTION
## 작업 내용 (Contents)
<!-- 이 PR에서 어떤 점들이 변경되었는지 기술해주세요.-->
- 입출금 계좌와 적금 계좌에 따른 계좌 해지 api 구현
- 적금 계좌 해지 시에는 이체 받을 계좌번호로  금액이 이체되게 구현함
- 계좌 해지 api 테스트 코드 추가

<br>

## 기타 사항 (Etc)
<!-- PR 에 대한 추가 설명이나 작업하면서 고민이 되었던 부분 등 -->
 **[간편 비밀번호 암호화]**
- 아직 회원 기능 구현 전이여서, 간편 비밀번호를 인증을 진행할 때 .equals 를 사용해서 비교하여 구현을 진행하였다. 
- 추후 회원 기능을 구현할 때, BCryptPasswordEncoder 을 사용하여 사용자가 간편 비밀번호를 입력할 때 입력값을 암호화하여 저장된 값을 비교할 예정이다. 

 **[적금 계좌 해지 시, 잔액 이동 로직 분리]**
- 적금 계좌를 해지 시, 해지 받을 계좌번호로 적금 금액이 이체가 된다. 
- blanceTransfer 메서드를 생성 후 해당 로직을 구현하였는데, 잔액 이동은 계좌 간의 거래이기 때문에 추후 거래 관리 api 를 구현할 때 balanceTransfer 를 따로 분리할 예정이다. 

<br>

## 테스트 (Test)
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요. -->
- [x] 계좌 해지 서비스 테스트 - 입출금 계좌
- [x] 계좌 해지 서비스 테스트 - 적금계좌
- [x] 사용자가 존재하지 않는 경우 - 계좌 해지 실패
- [x] 간편 비밀번호가 일치하지 않는 경우 - 계좌 해지 실패
- [x] 계좌번호가 존재하지 않는 경우 - 계좌 해지 실패
- [x] 계좌번호 소유주가 다른 경우 - 계좌 해지 실패
- [x] 계좌가 이미 해지 상태인 경우 - 계좌 해지 실패
- [x] API 테스트
